### PR TITLE
Refactor: 사용자 차종 저장 API에서 타이어 저장시 코드 수정

### DIFF
--- a/src/domain/entity/tire.entity.ts
+++ b/src/domain/entity/tire.entity.ts
@@ -23,6 +23,10 @@ export class Tire extends BaseModel {
 	@ApiProperty({ description: "multiValues" })
 	multiValues?: string;
 
+	@Column("varchar", { length: 2, nullable: false })
+	@ApiProperty({ description: "vehicle" })
+	vehicle!: string;
+
 	@Column("smallint", { nullable: false })
 	@ApiProperty({ description: "width" })
 	width!: number;
@@ -30,6 +34,10 @@ export class Tire extends BaseModel {
 	@Column("smallint", { nullable: false })
 	@ApiProperty({ description: "aspectRatio" })
 	aspectRatio!: number;
+
+	@Column("varchar", { length: 2, nullable: false })
+	@ApiProperty({ description: "construction" })
+	construction!: string;
 
 	@Column("smallint", { nullable: false })
 	@ApiProperty({ description: "wheelSize" })

--- a/src/domain/tier/tire.repository.ts
+++ b/src/domain/tier/tire.repository.ts
@@ -1,3 +1,4 @@
+import { tireParse } from "src/global/util/tireParse";
 import {
 	EntityManager,
 	EntityRepository,
@@ -16,28 +17,38 @@ export class TireRepository extends Repository<Tire> {
 		trim: Trim,
 		res
 	) {
-		const [frontWidth, frontRatio, frontWheelSzie] = res.frontTire.value
-			.replace(/[/R]/gi, ",")
-			.split(",")
-			.map((element) => parseInt(element));
+		const {
+			vehicle: frontVehicle,
+			width: frontWidth,
+			ratio: frontRatio,
+			construction: frontConstruction,
+			wheelSize: frontWheelSize
+		} = tireParse(res.frontTire.value);
 
-		const [rearWidth, rearRatio, rearWheelSzie] = res.rearTire.value
-			.replace(/[/R]/gi, ",")
-			.split(",")
-			.map((element) => parseInt(element));
+		const {
+			vehicle: rearVehicle,
+			width: rearWidth,
+			ratio: rearRatio,
+			construction: rearConstruction,
+			wheelSize: rearWheelSize
+		} = tireParse(res.rearTire.value);
 
 		const createFrontTire: Tire = await transactionManager.create(Tire, {
+			vehicle: frontVehicle,
+			construction: frontConstruction,
 			width: frontWidth,
 			aspectRatio: frontRatio,
-			wheelSize: frontWheelSzie,
+			wheelSize: frontWheelSize,
 			codeId: 1,
 			trim: trim
 		});
 
 		const createRearTire: Tire = await transactionManager.create(Tire, {
+			vehicle: rearVehicle,
+			construction: rearConstruction,
 			width: rearWidth,
 			aspectRatio: rearRatio,
-			wheelSize: rearWheelSzie,
+			wheelSize: rearWheelSize,
 			codeId: 2,
 			trim: trim
 		});
@@ -51,7 +62,7 @@ export class TireRepository extends Repository<Tire> {
 			.select("ti.unit", "unit")
 			.addSelect("ti.multiValues", "multiValues")
 			.addSelect(
-				`CONCAT(ti.width, '/', ti.aspectRatio, 'R', ti.wheelSize)`,
+				`CASE WHEN ti.width = 0 THEN "" ELSE CONCAT(ti.vehicle, ti.width, '/', ti.aspectRatio, ti.construction, ti.wheelSize) END`,
 				"value"
 			)
 			.addSelect(

--- a/src/global/util/tireParse.ts
+++ b/src/global/util/tireParse.ts
@@ -1,0 +1,38 @@
+interface parseValue {
+	vehicle: string;
+	width: number;
+	ratio: number;
+	construction: string;
+	wheelSize: number;
+}
+
+export function tireParse(tireInfo: string) {
+	const parse: parseValue = {
+		vehicle: "",
+		width: 0,
+		ratio: 0,
+		construction: "",
+		wheelSize: 0
+	};
+
+	if (tireInfo === "") {
+		return parse;
+	}
+
+	const [left, right] = tireInfo
+		.split("/")
+		.map((element) => element.match(/[\d\.]+|\D+/gi));
+	if (left.length > 1) {
+		parse.vehicle = left[0];
+		parse.width = parseInt(left[1]);
+	} else {
+		parse.vehicle = "";
+		parse.width = parseInt(left[0]);
+	}
+
+	parse.ratio = parseInt(right[0]);
+	parse.construction = right[1];
+	parse.wheelSize = parseInt(right[2]);
+
+	return parse;
+}


### PR DESCRIPTION
1. 사용자 차종 저장 API에서 타이어 저장시 코드 수정
- 기존의 타이어 parse 코드는 폭, 편평비, 휠사이즈만 가능했지만 그렇지 않은 경우도
존재했기 때문에 타이어 vehicle class 값과 타이어 fabric carcass 값의 컬럼을
추가하여 대처할 수 있도록 수정하였습니다.