### PR TITLE
Feat: 사용자 차종 등록 API 5개까지 가능하도록 변경, 에러 추가

### DIFF
--- a/src/domain/entity/trim.entity.ts
+++ b/src/domain/entity/trim.entity.ts
@@ -1,6 +1,5 @@
 import { ApiProperty } from "@nestjs/swagger";
 import {
-	Column,
 	Entity,
 	JoinColumn,
 	ManyToOne,

--- a/src/domain/tier/tire.controller.spec.ts
+++ b/src/domain/tier/tire.controller.spec.ts
@@ -1,4 +1,5 @@
 import { Test, TestingModule } from "@nestjs/testing";
+import { User } from "../entity/user.entity";
 import { NotFoundUserTrimException } from "../trim/exception/NotFoundUserTrimException";
 import { TireController } from "./tire.controller";
 import { TireService } from "./tire.service";
@@ -27,7 +28,8 @@ describe("TireController", () => {
 	describe("사용자 차종의 타이어 조회 API", () => {
 		it("사용자 차종의 타이어 조회 API 성공", async () => {
 			// given
-			const userId = "testid";
+			const user = new User();
+			user.id = "testid";
 			const trimId = 5000;
 			const tire = [
 				{
@@ -47,19 +49,20 @@ describe("TireController", () => {
 			mockTireService.findTrimTire.mockResolvedValue(tire);
 
 			// when
-			const res = await controller.getTrimTire(userId, trimId);
+			const res = await controller.getTrimTire(user, trimId);
 
 			// // then
 			expect(mockTireService.findTrimTire).toHaveBeenCalledTimes(1);
 			expect(mockTireService.findTrimTire).toHaveBeenCalledWith(
-				userId,
+				user.id,
 				trimId
 			);
 			expect(res).toEqual(tire);
 		});
 		it("사용자 차종의 타이어 조회 API 실패", async () => {
 			// given
-			const userId = "testid";
+			const user = new User();
+			user.id = "testid";
 			const trimId = 5001;
 
 			mockTireService.findTrimTire.mockResolvedValue(
@@ -68,7 +71,7 @@ describe("TireController", () => {
 
 			// when
 			try {
-				await controller.getTrimTire(userId, trimId);
+				await controller.getTrimTire(user, trimId);
 			} catch (e) {
 				// // then
 				expect(e).toEqual(NotFoundUserTrimException);

--- a/src/domain/tier/tire.controller.ts
+++ b/src/domain/tier/tire.controller.ts
@@ -2,6 +2,7 @@ import { Controller, Get, Query, Request, UseGuards } from "@nestjs/common";
 import { ApiOperation } from "@nestjs/swagger";
 import { AuthUser } from "src/global/decorator/authUser.decorator";
 import { JwtGuard } from "../auth/guard/jwt.guard";
+import { User } from "../entity/user.entity";
 import { TireService } from "./tire.service";
 
 @Controller("tire")
@@ -14,11 +15,8 @@ export class TireController {
 		summary: "사용자 차종의 타이어 조회 API",
 		description: "사용자가 소유한 자동차의 타이어 정보를 조회합니다."
 	})
-	async getTrimTire(
-		@AuthUser() userId: string,
-		@Query("trimId") trimId: number
-	) {
+	async getTrimTire(@AuthUser() user: User, @Query("trimId") trimId: number) {
 		console.log(trimId);
-		return await this.tireService.findTrimTire(userId, trimId);
+		return await this.tireService.findTrimTire(user.id, trimId);
 	}
 }

--- a/src/domain/trim/exception/DifferentTypeException.ts
+++ b/src/domain/trim/exception/DifferentTypeException.ts
@@ -1,0 +1,11 @@
+import { HttpException } from "@nestjs/common";
+import { ErrorCode } from "src/global/common/errorCode";
+
+export class DifferentTypeException extends HttpException {
+	constructor() {
+		super(
+			ErrorCode.DifferentType.Message,
+			ErrorCode.DifferentType.StatusCode
+		);
+	}
+}

--- a/src/domain/trim/exception/TypeLengthException.ts
+++ b/src/domain/trim/exception/TypeLengthException.ts
@@ -1,0 +1,8 @@
+import { HttpException } from "@nestjs/common";
+import { ErrorCode } from "src/global/common/errorCode";
+
+export class TypeLengthException extends HttpException {
+	constructor() {
+		super(ErrorCode.TypeLength.Message, ErrorCode.TypeLength.StatusCode);
+	}
+}

--- a/src/domain/trim/trim.controller.spec.ts
+++ b/src/domain/trim/trim.controller.spec.ts
@@ -1,4 +1,4 @@
-import { HttpModule, HttpService } from "@nestjs/axios";
+import { HttpModule } from "@nestjs/axios";
 import { ConfigModule } from "@nestjs/config";
 import { Test, TestingModule } from "@nestjs/testing";
 import { Trim } from "../entity/trim.entity";
@@ -36,9 +36,11 @@ describe("TrimController", () => {
 	describe("외부 API 사용", () => {
 		it("외부 API 사용하여 차종 정보 및 타이어 정보 저장", async () => {
 			// given
+			const dtoArr: SaveUserTrimDto[] = [];
 			const dto = new SaveUserTrimDto();
 			dto.id = "testid";
 			dto.trimId = 5000;
+			dtoArr.push(dto);
 
 			const trim = new Trim();
 			trim.trimId = 5000;
@@ -46,11 +48,11 @@ describe("TrimController", () => {
 			mockTrimService.saveUserTrim.mockResolvedValue(trim);
 
 			// when
-			const res = await controller.userTrim(dto);
+			const res = await controller.userTrim(dtoArr);
 
 			// // then
 			expect(mockTrimService.saveUserTrim).toHaveBeenCalledTimes(1);
-			expect(res.trimId).toEqual(5000);
+			expect(res[0].trimId).toEqual(5000);
 		});
 	});
 });

--- a/src/domain/user/user.controller.spec.ts
+++ b/src/domain/user/user.controller.spec.ts
@@ -81,19 +81,15 @@ describe("UserController", () => {
 			user.createdAt = new Date();
 			user.updatedAt = new Date();
 
-			const req = {
-				user: user
-			};
-
 			const token = "tokentokentoken";
 			mockAuthService.makeToken.mockResolvedValue(token);
 
 			// when
-			const res = await controller.login(req);
+			const res = await controller.login(user);
 
 			// then
 			expect(mockAuthService.makeToken).toHaveBeenCalledTimes(1);
-			expect(mockAuthService.makeToken).toHaveBeenCalledWith(req.user);
+			expect(mockAuthService.makeToken).toHaveBeenCalledWith(user);
 			expect(res).toHaveProperty("token");
 		});
 	});

--- a/src/domain/user/user.controller.ts
+++ b/src/domain/user/user.controller.ts
@@ -1,7 +1,9 @@
 import { Body, Controller, Post, Request, UseGuards } from "@nestjs/common";
 import { ApiOperation } from "@nestjs/swagger";
+import { AuthUser } from "src/global/decorator/authUser.decorator";
 import { AuthService } from "../auth/auth.service";
 import { LocalAuthGuard } from "../auth/guard/localAuth.guard";
+import { User } from "../entity/user.entity";
 import { CreateUserDto } from "./dto/createUser.dto";
 import { UserService } from "./user.service";
 
@@ -27,7 +29,7 @@ export class UserController {
 		summary: "로그인 API",
 		description: "로그인시 토큰을 반환합니다."
 	})
-	async login(@Request() req) {
-		return { token: this.authService.makeToken(req.user) };
+	async login(@AuthUser() user: User) {
+		return { token: this.authService.makeToken(user) };
 	}
 }

--- a/src/global/common/errorCode.ts
+++ b/src/global/common/errorCode.ts
@@ -22,6 +22,16 @@ export class ErrorCode {
 		"사용자가 이미 등록한 차종입니다."
 	);
 
+	static readonly DifferentType = new ErrorCode(
+		HttpStatus.INTERNAL_SERVER_ERROR,
+		"잘못된 형식의 요청입니다. 다시 확인해주세요."
+	);
+
+	static readonly TypeLength = new ErrorCode(
+		HttpStatus.INTERNAL_SERVER_ERROR,
+		"요청은 최소 하나 이상, 최대 5개 이하여야 합니다."
+	);
+
 	constructor(
 		private readonly statusCode: number,
 		public readonly message: string

--- a/src/global/decorator/authUser.decorator.ts
+++ b/src/global/decorator/authUser.decorator.ts
@@ -3,6 +3,6 @@ import { createParamDecorator, ExecutionContext } from "@nestjs/common";
 export const AuthUser = createParamDecorator(
 	(data: unknown, ctx: ExecutionContext) => {
 		const request = ctx.switchToHttp().getRequest();
-		return request.user.id;
+		return request.user;
 	}
 );

--- a/src/global/decorator/saveUserTrimModel.ts
+++ b/src/global/decorator/saveUserTrimModel.ts
@@ -1,0 +1,29 @@
+import {
+	createParamDecorator,
+	ExecutionContext,
+	UseFilters
+} from "@nestjs/common";
+import { SaveUserTrimDto } from "src/domain/trim/dto/saveUserTrim.dto";
+import { DifferentTypeException } from "src/domain/trim/exception/DifferentTypeException";
+import { TypeLengthException } from "src/domain/trim/exception/TypeLengthException";
+
+export const saveUserTrimModel = createParamDecorator(
+	(data: unknown, ctx: ExecutionContext) => {
+		const request = ctx.switchToHttp().getRequest().body;
+
+		if (request.length > 5 || request.length < 1) {
+			throw new TypeLengthException();
+		}
+
+		try {
+			return request.map((element) => {
+				const dto = new SaveUserTrimDto();
+				dto.id = element.id;
+				dto.trimId = element.trimId;
+				return dto;
+			});
+		} catch (e) {
+			throw new DifferentTypeException();
+		}
+	}
+);

--- a/src/global/exceptionHandler/exceptionHandler.ts
+++ b/src/global/exceptionHandler/exceptionHandler.ts
@@ -3,8 +3,10 @@ import {
 	ExceptionFilter,
 	UnauthorizedException
 } from "@nestjs/common";
+import { DifferentTypeException } from "src/domain/trim/exception/DifferentTypeException";
 import { NotFoundUserTrimException } from "src/domain/trim/exception/NotFoundUserTrimException";
 import { TrimOverlapException } from "src/domain/trim/exception/TrimOverlapException";
+import { TypeLengthException } from "src/domain/trim/exception/TypeLengthException";
 import { NotFoundUserException } from "src/domain/user/exception/NotFoundUserException";
 import { UserOverlapException } from "src/domain/user/exception/UserOverlapException";
 import { ErrorCode } from "../common/errorCode";
@@ -40,6 +42,16 @@ export class ExceptionHandler implements ExceptionFilter {
 			response
 				.status(status)
 				.json(ErrorResponse.response(ErrorCode.TrimOverlap));
+		} else if (exception instanceof DifferentTypeException) {
+			const status = exception.getStatus();
+			response
+				.status(status)
+				.json(ErrorResponse.response(ErrorCode.DifferentType));
+		} else if (exception instanceof TypeLengthException) {
+			const status = exception.getStatus();
+			response
+				.status(status)
+				.json(ErrorResponse.response(ErrorCode.TypeLength));
 		} else {
 			const status = exception.getStatus();
 			response.status(status).json({


### PR DESCRIPTION
1. 사용자 차종 등록 API 5개까지 가능하도록 변경
- 새로운 데코레이터를 만들어서 최소 1개 최대 5개이상 가능하도록 변경

2. 에러 추가
- saveUserTrimDto에 맞지 않으면 DifferentTypeException 발생
- 처리 가능한 숫자를 넘어가면 TypeLengthException 발생